### PR TITLE
feat(rwlock): Use parking lot for fairness in locking

### DIFF
--- a/locator/Cargo.toml
+++ b/locator/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2024"
 axum = "0.8.4"
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.46.1", features = ["full"] }
+parking_lot = "0.12.4"
+

--- a/locator/src/org_to_cell_mapping.rs
+++ b/locator/src/org_to_cell_mapping.rs
@@ -1,7 +1,8 @@
-use std::{collections::HashMap, sync::RwLock};
+use std::{collections::HashMap};
 use std::sync::Arc;
 use std::time::SystemTime;
 use std::fmt;
+use parking_lot::RwLock;
 
 
 #[derive(Debug)]
@@ -73,9 +74,9 @@ impl OrgToCell {
         // Returns an `Option<Cell>` if found, or `None` if not found.
         // Returns an error if locality is passed and the org_id/locality pair is not valid.
         // Or if a locality is passed but no defualt cell is found for that locality
-        let guard = self.inner.read().unwrap();
+        let read_guard = self.inner.read();
 
-        let cell = guard.mapping.get(org_id);
+        let cell = read_guard.mapping.get(org_id);
 
         match cell {
             Some(cell) => {
@@ -89,7 +90,7 @@ impl OrgToCell {
             }
             None => {
                 if let Some(locality) = locality {
-                    if let Some(default_cell) = guard.locality_to_default_cell.get(locality) {
+                    if let Some(default_cell) = read_guard.locality_to_default_cell.get(locality) {
                         return Ok(Some(default_cell.clone()));
                     } else {
                         return Err(LookupError::new(&format!("No cell found for org_id '{}' and locality '{}'", org_id, locality)));
@@ -120,10 +121,8 @@ impl OrgToCell {
         }
 
 
-        let mut guard = self.inner.write().unwrap();
-        guard.mapping = dummy_data;
-        guard.last_updated = Some(SystemTime::now());
+        let mut write_guard = self.inner.write();
+        write_guard.mapping = dummy_data;
+        write_guard.last_updated = Some(SystemTime::now());
     }
-
-
 }


### PR DESCRIPTION
The standard RwLock does not guarantee fairness between the read and write lock accesses. In a high throughput system, there will be a lots of reads happening. So there is a chance that writes might not go through. In order to avoid this scenario, use parking lot RwLock which guarantees fairness between reads and writes.
