### PR TITLE
proxy: implement route parsing and matching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Synapse Rust workspace
 
-.PHONY: help setup build test clean fmt fmt-check lint fix check dev-locator dev-proxy run-locator run-proxy run-mock-control-api
+.PHONY: help setup build test clean fmt fmt-check lint fix check dev-locator dev-proxy run-locator run-proxy run-echo-server run-mock-control-api
 
 # Default target
 help:
@@ -68,7 +68,7 @@ run-locator:
 	cargo run locator --config-file-path example_config_locator.yaml
 
 run-proxy:
-	cargo run proxy
+	cargo run proxy --config-file-path example_config_proxy.yaml
 
 run-ingest-router:
 	cargo run ingest-router

--- a/locator/src/lib.rs
+++ b/locator/src/lib.rs
@@ -68,7 +68,11 @@ struct Params {
     locality: Option<String>,
 }
 
-pub async fn run(config: config::Config) {
+#[derive(thiserror::Error, Debug)]
+#[error("locator error")]
+pub struct LocatorError;
+
+pub async fn run(config: config::Config) -> Result<(), LocatorError> {
     // Dummy data for testing. The real provider implementation should be selected based on config.
     let route_provider = get_provider(config.backup_route_store.r#type);
 
@@ -88,6 +92,8 @@ pub async fn run(config: config::Config) {
         .await
         .unwrap();
     axum::serve(listener, app).await.unwrap();
+
+    Ok(())
 }
 
 async fn handler(

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -18,7 +18,7 @@ The proxy supports two locator modes - `in_process` or `url`.
 
 ### Deterministic route matching
 
-Routes are matched top down in the order they are defined. For each incoming request, the proxy checks the host, path and method against the route’s match block, and executes the first action that matches all three.
+Routes are matched top down in the order they are defined. For each incoming request, the proxy checks the host and path against the route’s match block, and executes the first action that matches.
 
 **Route matching examples:**
 
@@ -27,7 +27,6 @@ Routes are matched top down in the order they are defined. For each incoming req
     - match:
         host: "*"       # host can be anything
         path: /health/  # only the exact path /health/ will be matched
-        methods: [GET]  #  only get requests will be matched
     ```
 
 2. Match any path
@@ -35,7 +34,6 @@ Routes are matched top down in the order they are defined. For each incoming req
     - match:
         host: de.sentry.io  # match de.sentry.io only
         path: "*"           # all paths
-        methods: [ALL]      # all methods
     ```
 
 3. Path prefix match with dynamic segment
@@ -43,7 +41,6 @@ Routes are matched top down in the order they are defined. For each incoming req
     - match:
         host: us.sentry.io                                 # matches us.sentry.io only
         path: /organizations/{organization_id_or_slug}/*   # with {organization_id_or_slug} dynamic segment and trailing wildcard
-        methods: [ALL]                                     # all methods
     ```
 
 ### Route actions
@@ -73,7 +70,6 @@ Each route is associated with an action, which can be a static or dynamic routin
 ### Infrastructure endpoints
 
 Infrastructure endpoints are exposed on a dedicated host/port in order to avoid exposure of admin endpoints to end users, and to prevent collisions with endpoints on proxied services. The host/port can be configured via the `admin_listener` block in the config file.
-
 
 These include:
 - `/health`

--- a/proxy/src/admin_service.rs
+++ b/proxy/src/admin_service.rs
@@ -11,7 +11,7 @@ pub struct AdminService {}
 
 impl AdminService {
     pub fn new() -> Self {
-        AdminService {}
+        Self {}
     }
 }
 

--- a/proxy/src/errors.rs
+++ b/proxy/src/errors.rs
@@ -1,0 +1,9 @@
+use std::io;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ProxyError {
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+    #[error("configuration error")]
+    InvalidRoute,
+}

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -1,29 +1,25 @@
 mod admin_service;
 pub mod config;
+mod errors;
 mod proxy_service;
 mod route_actions;
 mod service;
 
+use crate::errors::ProxyError;
 use hyper_util::rt::TokioExecutor;
 use hyper_util::rt::TokioIo;
 use hyper_util::server::conn::auto::Builder;
 use service::ServiceType;
-use std::io;
-use std::process;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 
-#[derive(thiserror::Error, Debug)]
-pub enum ProxyError {
-    #[error("I/O error: {0}")]
-    Io(#[from] io::Error),
-}
-
-pub async fn run(config: config::Config) {
+pub async fn run(config: config::Config) -> Result<(), ProxyError> {
     let proxy_task = run_task(
         &config.listener.host,
         config.listener.port,
-        ServiceType::Proxy(Box::new(proxy_service::ProxyService::new(config.clone()))),
+        ServiceType::Proxy(Box::new(proxy_service::ProxyService::try_new(
+            config.clone(),
+        )?)),
     );
     let admin_task = run_task(
         &config.admin_listener.host,
@@ -31,10 +27,9 @@ pub async fn run(config: config::Config) {
         ServiceType::Admin(Box::new(admin_service::AdminService::new())),
     );
 
-    if let Err(e) = tokio::try_join!(proxy_task, admin_task) {
-        eprintln!("Proxy error: {}", e);
-        process::exit(1);
-    }
+    tokio::try_join!(proxy_task, admin_task)?;
+
+    Ok(())
 }
 
 async fn run_task(host: &str, port: u16, service: ServiceType) -> Result<(), ProxyError> {

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -1,10 +1,12 @@
 use crate::config;
+use crate::errors::ProxyError;
 use crate::route_actions::RouteActions;
 use bytes::Bytes;
 use http_body_util::combinators::BoxBody;
+use http_body_util::{BodyExt, Full};
 use hyper::body::Incoming;
 use hyper::service::Service as HyperService;
-use hyper::{Request, Response};
+use hyper::{Request, Response, StatusCode};
 use hyper_util::client::legacy::Client;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
@@ -15,23 +17,23 @@ use std::pin::Pin;
 pub struct ProxyService {
     config: config::Config,
     client: Client<HttpConnector, Incoming>,
-    route_actions: RouteActions,
+    pub route_actions: RouteActions,
 }
 
 impl ProxyService {
-    pub fn new(config: config::Config) -> Self {
+    pub fn try_new(config: config::Config) -> Result<Self, ProxyError> {
         let conn = HttpConnector::new();
         let client: Client<_, Incoming> = Client::builder(TokioExecutor::new())
             .http2_adaptive_window(true)
             .build(conn);
 
-        let route_actions = RouteActions::new(config.routes.clone());
+        let route_actions = RouteActions::try_new(config.routes.clone())?;
 
-        Self {
+        Ok(Self {
             config,
             client,
             route_actions,
-        }
+        })
     }
 }
 
@@ -42,8 +44,19 @@ impl HyperService<Request<Incoming>> for ProxyService {
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
     fn call(&self, request: Request<Incoming>) -> Self::Future {
-        let _route = self.route_actions.resolve(&request);
+        let route = self.route_actions.resolve(&request);
 
-        unimplemented!();
+        println!("Resolved route: {:?}", route);
+        Box::pin(async move {
+            let res = Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(
+                    Full::new("not found\n".into())
+                        .map_err(|e| match e {})
+                        .boxed(),
+                )
+                .unwrap();
+            Ok(res)
+        })
     }
 }

--- a/proxy/src/route_actions.rs
+++ b/proxy/src/route_actions.rs
@@ -1,18 +1,278 @@
-use crate::config::Route;
+use crate::config::{Action, Route as RouteConfig};
+use crate::errors::ProxyError;
 use hyper::body::Incoming;
+use std::collections::HashMap;
+
+#[derive(Debug)]
+enum PathSegment {
+    Static(String),
+    Param(String),
+}
+
+#[derive(Debug)]
+struct Path {
+    segments: Vec<PathSegment>,
+    has_trailing_splat: bool,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct RouteMatch<'a> {
+    #[allow(dead_code)]
+    params: HashMap<&'a str, &'a str>,
+}
+
+#[derive(Debug)]
+struct Route {
+    host: Option<String>,
+    path: Option<Path>,
+    #[allow(dead_code)]
+    action: Action,
+}
+
+impl Route {
+    // Returns Some(RouteMatch) if the request matches this route, None otherwise.
+    // Trailing slash normalization is applied to incoming requests.
+    fn matches<'a>(
+        &'a self,
+        request_host: Option<&str>,
+        request_path: &'a str,
+    ) -> Option<RouteMatch<'a>> {
+        if self.host.is_some() && self.host.as_deref() != request_host {
+            return None;
+        }
+
+        let normalized_path = request_path.trim().trim_matches('/');
+
+        let request_segments: Vec<&str> = if normalized_path.is_empty() {
+            vec![]
+        } else {
+            normalized_path.split('/').collect()
+        };
+
+        let mut params = HashMap::new();
+        let mut i_req = 0;
+
+        match &self.path {
+            Some(path) => {
+                for seg in path.segments.iter() {
+                    match seg {
+                        PathSegment::Static(s) => {
+                            let req_segment = *request_segments.get(i_req)?;
+                            if req_segment != s {
+                                return None;
+                            }
+                            i_req += 1;
+                        }
+                        PathSegment::Param(name) => {
+                            let req_segment = *request_segments.get(i_req)?;
+                            params.insert(name.as_str(), req_segment);
+                            i_req += 1;
+                        }
+                    }
+                }
+
+                if path.has_trailing_splat || i_req == request_segments.len() {
+                    return Some(RouteMatch { params });
+                } else {
+                    return None;
+                }
+            }
+            None => {
+                // If no path is defined in the route, it matches anything
+                return Some(RouteMatch { params });
+            }
+        }
+    }
+}
+
+impl TryFrom<RouteConfig> for Route {
+    type Error = ProxyError;
+    fn try_from(config: RouteConfig) -> Result<Self, Self::Error> {
+        // TODO: Add route validation
+
+        let path = config.r#match.path.map(|path_str| {
+            // Trim slashes
+            let mut normalized_path = path_str.trim().trim_matches('/');
+
+            // Handle trailing splat
+            let mut has_trailing_splat = false;
+            if let Some(stripped) = normalized_path.strip_suffix("/*") {
+                has_trailing_splat = true;
+                normalized_path = stripped;
+            }
+
+            let segments: Vec<PathSegment> = if normalized_path.is_empty() {
+                vec![]
+            } else {
+                normalized_path
+                    .split('/')
+                    .map(|s| {
+                        if let Some(stripped) =
+                            s.strip_prefix('{').and_then(|s| s.strip_suffix('}'))
+                        {
+                            PathSegment::Param(stripped.to_string())
+                        } else {
+                            PathSegment::Static(s.to_string())
+                        }
+                    })
+                    .collect()
+            };
+            Path {
+                segments,
+                has_trailing_splat,
+            }
+        });
+
+        Ok(Self {
+            host: config.r#match.host,
+            path,
+            action: config.action,
+        })
+    }
+}
 
 pub struct RouteActions {
-    #[allow(dead_code)]
     routes: Vec<Route>,
 }
 
 impl RouteActions {
-    pub fn new(routes: Vec<Route>) -> Self {
-        Self { routes }
+    pub fn try_new(route_config: Vec<RouteConfig>) -> Result<Self, ProxyError> {
+        let routes: Vec<Route> = route_config
+            .into_iter()
+            .map(|c| Route::try_from(c))
+            .collect::<Result<_, _>>()?;
+
+        Ok(Self { routes })
     }
     /// Matches the incoming request to a route, and returns the first matched route if any.
     /// If no matches are found, return none.
-    pub fn resolve(&self, _request: &http::Request<Incoming>) -> Option<&Route> {
-        unimplemented!();
+    pub fn resolve<'a>(&'a self, request: &'a http::Request<Incoming>) -> Option<RouteMatch<'a>> {
+        println!("Resolving route for request: {:?}", request);
+
+        // Host may come from authority part of URI (if absolute-form request)
+        // or from the Host header (most common in HTTP/1.1).
+        let host = request
+            .uri()
+            .host()
+            .or_else(|| request.headers().get("host").and_then(|h| h.to_str().ok()));
+
+        let path = request.uri().path();
+        let query = request.uri().query();
+
+        println!("Request path: {}", path);
+        println!("Request query: {:?}", query);
+
+        for route in &self.routes {
+            println!("Checking route: {:?}", route);
+            let route_match = route.matches(host, path);
+            println!("Route match: {:?}", route_match);
+
+            if let Some(m) = route_match {
+                return Some(m);
+            }
+        }
+
+        // No matching route found
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_host_only() {
+        let config = RouteConfig {
+            r#match: crate::config::Match {
+                host: Some("sentry.io".to_string()),
+                path: None,
+            },
+            action: crate::config::Action::Static {
+                to: "upstream".to_string(),
+            },
+        };
+
+        let route = Route::try_from(config).unwrap();
+        assert!(route.matches(Some("sentry.io"), "/").is_some());
+        assert!(route.matches(Some("other.com"), "/").is_none());
+        assert!(route.matches(None, "/").is_none());
+    }
+
+    #[test]
+    fn test_static_path() {
+        let config = RouteConfig {
+            r#match: crate::config::Match {
+                host: None,
+                path: Some("/api/test/".to_string()),
+            },
+            action: crate::config::Action::Static {
+                to: "upstream".to_string(),
+            },
+        };
+
+        let route = Route::try_from(config).unwrap();
+        assert!(route.matches(None, "/api/test").is_some(), "exact path");
+        assert!(
+            route.matches(None, "/api/test/").is_some(),
+            "with trailing slash normalization"
+        );
+        assert!(
+            route.matches(None, "/api/test/2").is_none(),
+            "extra segment doesn't match"
+        );
+        assert!(
+            route.matches(None, "/api/").is_none(),
+            "missing segment doesn't match"
+        );
+    }
+
+    #[test]
+    fn test_trailing_splat() {
+        let config = RouteConfig {
+            r#match: crate::config::Match {
+                host: None,
+                path: Some("/api/test/*".to_string()),
+            },
+            action: crate::config::Action::Static {
+                to: "upstream".to_string(),
+            },
+        };
+
+        let route = Route::try_from(config).unwrap();
+        assert!(route.matches(None, "/api/test").is_some(), "exact path");
+        assert!(
+            route.matches(None, "/api/test/extra").is_some(),
+            "extra segment is allowed"
+        );
+        assert!(route.matches(None, "/api/").is_none(), "missing segment");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_illegal_splat_patterns() {
+        unimplemented!("add validation on route creation for illegal patterns");
+    }
+
+    #[test]
+    fn test_dymamic_path() {
+        let config = RouteConfig {
+            r#match: crate::config::Match {
+                host: None,
+                path: Some("/api/users/{user_id}".to_string()),
+            },
+            action: crate::config::Action::Static {
+                to: "upstream".to_string(),
+            },
+        };
+
+        let route = Route::try_from(config).unwrap();
+
+        assert_eq!(
+            route.matches(None, "/api/users/123"),
+            Some(RouteMatch {
+                params: HashMap::from([("user_id", "123")])
+            })
+        );
     }
 }

--- a/proxy/src/route_actions.rs
+++ b/proxy/src/route_actions.rs
@@ -162,18 +162,9 @@ impl RouteActions {
         println!("Request path: {}", path);
         println!("Request query: {:?}", query);
 
-        for route in &self.routes {
-            println!("Checking route: {:?}", route);
-            let route_match = route.matches(host, path);
-            println!("Route match: {:?}", route_match);
+        // Return the first matching route, if any
+        self.routes.iter().find_map(|route| route.matches(host, path))
 
-            if let Some(m) = route_match {
-                return Some(m);
-            }
-        }
-
-        // No matching route found
-        None
     }
 }
 

--- a/synapse/src/main.rs
+++ b/synapse/src/main.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 mod config;
 use config::Config;
+use std::process;
 
 #[derive(Parser)]
 enum CliCommand {
@@ -53,12 +54,15 @@ fn cli() -> Result<(), CliError> {
     }
 }
 
-pub fn run_async(fut: impl Future<Output = ()>) {
+pub fn run_async(fut: impl Future<Output = Result<(), impl std::error::Error>>) {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .unwrap();
-    rt.block_on(fut);
+    if let Err(e) = rt.block_on(fut) {
+        eprintln!("Error: {}", e);
+        process::exit(1);
+    }
 }
 
 #[derive(Args, Debug, Clone)]


### PR DESCRIPTION
- implement parsing of yaml configuratio into `Route` struct
- implement `Route::matches` to compare route to incoming request host and path values
- add tests for exact matching, dymamic matching, trailing splats
- remove matching by http method. this was previously documented but is not needed.