### PR TITLE
devservices: add config for proxy and ingest-router

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -1,0 +1,44 @@
+x-sentry-service-config:
+  version: 0.1
+  service_name: synapse
+  description: Cell routing services (proxy + ingest-router).
+  modes:
+    default:
+      - synapse-proxy
+      - synapse-ingest-router
+
+services:
+  synapse-proxy:
+    image: us-docker.pkg.dev/sentryio/synapse/image:latest
+    command: ["proxy", "--config-file-path", "/app/proxy.yaml"]
+    ports:
+      - "13000:3000"
+      - "13001:3001"
+    volumes:
+      - ./proxy.yaml:/app/proxy.yaml:ro
+      - synapse-proxy-cache:/tmp/synapse-cache
+    networks:
+      - devservices
+    restart: unless-stopped
+
+  synapse-ingest-router:
+    image: us-docker.pkg.dev/sentryio/synapse/image:latest
+    command: ["ingest-router", "--config-file-path", "/app/ingest-router.yaml"]
+    ports:
+      - "13002:3000"
+      - "13003:3001"
+    volumes:
+      - ./ingest-router.yaml:/app/ingest-router.yaml:ro
+      - synapse-ingest-router-cache:/tmp/synapse-cache
+    networks:
+      - devservices
+    restart: unless-stopped
+
+volumes:
+  synapse-proxy-cache:
+  synapse-ingest-router-cache:
+
+networks:
+  devservices:
+    name: devservices
+    external: true

--- a/devservices/ingest-router.yaml
+++ b/devservices/ingest-router.yaml
@@ -9,7 +9,7 @@ ingest_router:
   locator:
     type: in_process
     control_plane:
-      url: http://dev.getsentry.net:8000
+      url: http://host.docker.internal:8000
     backup_route_store:
       type: filesystem
       base_dir: /tmp/synapse-cache
@@ -23,8 +23,8 @@ ingest_router:
   locales:
     "--monolith--":
       - id: "--monolith--"
-        sentry_url: http://dev.getsentry.net:8000
-        relay_url: TODO
+        sentry_url: http://host.docker.internal:8000
+        relay_url: http://relay:7899
 
   routes:
     - match:

--- a/devservices/ingest-router.yaml
+++ b/devservices/ingest-router.yaml
@@ -9,7 +9,7 @@ ingest_router:
   locator:
     type: in_process
     control_plane:
-      url: http://localhost:8000
+      url: http://dev.getsentry.net:8000
     backup_route_store:
       type: filesystem
       base_dir: /tmp/synapse-cache
@@ -23,7 +23,7 @@ ingest_router:
   locales:
     "--monolith--":
       - id: "--monolith--"
-        sentry_url: http://localhost:8000
+        sentry_url: http://dev.getsentry.net:8000
         relay_url: TODO
 
   routes:

--- a/devservices/ingest-router.yaml
+++ b/devservices/ingest-router.yaml
@@ -1,0 +1,68 @@
+ingest_router:
+  listener:
+    host: "0.0.0.0"
+    port: 3000
+  admin_listener:
+    host: "0.0.0.0"
+    port: 3001
+
+  locator:
+    type: in_process
+    control_plane:
+      url: http://localhost:8000
+    backup_route_store:
+      type: filesystem
+      base_dir: /tmp/synapse-cache
+      filename: backup.bin
+      compression: zstd1
+    localities:
+      - "--monolith--"
+    locality_to_default_cell:
+      "--monolith--": "--monolith--"
+
+  locales:
+    "--monolith--":
+      - id: "--monolith--"
+        sentry_url: http://localhost:8000
+        relay_url: TODO
+
+  routes:
+    - match:
+        host: localhost
+        path: /api/0/relays/projectconfigs/
+        method: POST
+      action:
+        handler: relay_project_configs
+      locale: "--monolith--"
+    - match:
+        host: localhost
+        path: /api/0/relays/live/
+        method: GET
+      action:
+        handler: health
+      locale: "--monolith--"
+    - match:
+        host: localhost
+        path: /api/0/relays/register/challenge/
+        method: POST
+      action:
+        handler: register_challenge
+      locale: "--monolith--"
+    - match:
+        host: localhost
+        path: /api/0/relays/register/response/
+        method: POST
+      action:
+        handler: register_response
+      locale: "--monolith--"
+    - match:
+        host: localhost
+        path: /api/0/relays/publickeys/
+        method: POST
+      action:
+        handler: public_keys
+      locale: "--monolith--"
+
+metrics:
+  statsd_host: "127.0.0.1"
+  statsd_port: 8126

--- a/devservices/proxy.yaml
+++ b/devservices/proxy.yaml
@@ -8,7 +8,7 @@ proxy:
   locator:
     type: in_process
     control_plane:
-      url: http://localhost:8000
+      url: http://dev.getsentry.net:8000
     backup_route_store:
       type: filesystem
       base_dir: /tmp/synapse-cache
@@ -20,7 +20,7 @@ proxy:
       "--monolith--": "--monolith--"
   upstreams:
     - name: sentry-dev-monolith
-      url: http://localhost:8000
+      url: http://dev.getsentry.net:8000
   routes:
     - match:
         host: localhost

--- a/devservices/proxy.yaml
+++ b/devservices/proxy.yaml
@@ -8,7 +8,7 @@ proxy:
   locator:
     type: in_process
     control_plane:
-      url: http://dev.getsentry.net:8000
+      url: http://host.docker.internal:8000
     backup_route_store:
       type: filesystem
       base_dir: /tmp/synapse-cache
@@ -20,7 +20,7 @@ proxy:
       "--monolith--": "--monolith--"
   upstreams:
     - name: sentry-dev-monolith
-      url: http://dev.getsentry.net:8000
+      url: http://host.docker.internal:8000
   routes:
     - match:
         host: localhost

--- a/devservices/proxy.yaml
+++ b/devservices/proxy.yaml
@@ -1,0 +1,36 @@
+proxy:
+  listener:
+    host: "0.0.0.0"
+    port: 3000
+  admin_listener:
+    host: "0.0.0.0"
+    port: 3001
+  locator:
+    type: in_process
+    control_plane:
+      url: http://localhost:8000
+    backup_route_store:
+      type: filesystem
+      base_dir: /tmp/synapse-cache
+      filename: backup.bin
+      compression: zstd1
+    localities:
+      - "--monolith--"
+    locality_to_default_cell:
+      "--monolith--": "--monolith--"
+  upstreams:
+    - name: sentry-dev-monolith
+      url: http://localhost:8000
+  routes:
+    - match:
+        host: localhost
+        path: /organizations/{organization}/*
+      action:
+        resolver: cell_from_organization
+        cell_to_upstream:
+          "--monolith--": sentry-dev-monolith
+        # default: sentry-dev-monolith
+
+metrics:
+  statsd_host: "127.0.0.1"
+  statsd_port: 8126


### PR DESCRIPTION
Adds devservices/config.yml so synapse can be brought up as a remote dependency of Sentry's cell-routing mode, plus single-cell dev configs for the `synapse-proxy` and `synapse-ingest-router` services.