### PR TITLE
devservices: Add healthchecks for proxy and ingest-router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,6 +3292,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-statsd",
  "proxy",
+ "reqwest",
  "sentry",
  "serde",
  "serde_yaml",

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -24,6 +24,11 @@ services:
       - synapse-proxy-cache:/tmp/synapse-cache
     networks:
       - devservices
+    healthcheck:
+      test: ["CMD", "/app/synapse", "healthcheck", "--config-file-path", "/app/proxy.yaml"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
     restart: unless-stopped
 
   synapse-ingest-router:
@@ -37,6 +42,11 @@ services:
       - synapse-ingest-router-cache:/tmp/synapse-cache
     networks:
       - devservices
+    healthcheck:
+      test: ["CMD", "/app/synapse", "healthcheck", "--config-file-path", "/app/ingest-router.yaml"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
     restart: unless-stopped
 
 volumes:

--- a/synapse/Cargo.toml
+++ b/synapse/Cargo.toml
@@ -10,6 +10,7 @@ locator = { path = "../locator" }
 metrics = { workspace = true }
 metrics-exporter-statsd = { workspace = true }
 proxy = { path = "../proxy" }
+reqwest = { workspace = true, features = ["blocking"] }
 sentry = { workspace = true }
 serde = { workspace = true }
 shared = { path = "../shared" }

--- a/synapse/src/healthcheck.rs
+++ b/synapse/src/healthcheck.rs
@@ -1,0 +1,24 @@
+use crate::CliError;
+use crate::config::Config;
+use std::path::Path;
+
+pub fn run(config_path: &Path) -> Result<(), CliError> {
+    let config = Config::from_file(config_path)?;
+    let port = config
+        .proxy
+        .as_ref()
+        .map(|c| c.admin_listener.port)
+        .or_else(|| config.ingest_router.as_ref().map(|c| c.admin_listener.port))
+        .ok_or(CliError::InvalidConfig(
+            "Missing proxy or ingest-router config",
+        ))?;
+    let response = reqwest::blocking::get(format!("http://localhost:{port}/ready"))
+        .map_err(|e| CliError::HealthcheckFailed(e.to_string()))?;
+    if !response.status().is_success() {
+        return Err(CliError::HealthcheckFailed(format!(
+            "status {}",
+            response.status()
+        )));
+    }
+    Ok(())
+}

--- a/synapse/src/main.rs
+++ b/synapse/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Args, Parser};
 use std::path::PathBuf;
 
 mod config;
+mod healthcheck;
 use config::{Config, MetricsConfig};
 use metrics_exporter_statsd::StatsdBuilder;
 use std::future::Future;
@@ -14,6 +15,8 @@ enum CliCommand {
     Locator(LocatorArgs),
     Proxy(ProxyArgs),
     IngestRouter(IngestRouterArgs),
+    /// Probe a URL and exit 0 on a 2xx response, non-zero otherwise.
+    Healthcheck(HealthcheckArgs),
     /// Show all metrics definitions as markdown table
     ShowMetrics,
     /// Sync METRICS.md with current metric definitions
@@ -28,6 +31,8 @@ enum CliError {
     InvalidConfig(&'static str),
     #[error("Failed to create runtime: {0}")]
     RuntimeError(#[from] std::io::Error),
+    #[error("Healthcheck failed: {0}")]
+    HealthcheckFailed(String),
 }
 
 fn main() {
@@ -81,6 +86,7 @@ fn cli() -> Result<(), CliError> {
 
             Ok(())
         }
+        CliCommand::Healthcheck(args) => healthcheck::run(&args.base.config_file_path),
         CliCommand::ShowMetrics => {
             println!("## Locator Metrics\n");
             println!(
@@ -238,6 +244,12 @@ struct ProxyArgs {
 
 #[derive(Args, Debug)]
 struct IngestRouterArgs {
+    #[command(flatten)]
+    base: BaseArgs,
+}
+
+#[derive(Args, Debug)]
+struct HealthcheckArgs {
     #[command(flatten)]
     base: BaseArgs,
 }


### PR DESCRIPTION
Adds a `synapse healthcheck` subcommand that probes the admin listeners ready endpoint.

This approach was used instead of the standard `curl` since we want the runtime image is distroless and we want to keep it as minimal as possible - no shell, curl, or wget exists inside the container.

This is a similar pattern to relay's healthcheck command.