### PR TITLE
feat: Update default ports to align with Sentry dev

### DIFF
--- a/example_config_ingest_router.yaml
+++ b/example_config_ingest_router.yaml
@@ -10,7 +10,7 @@ ingest_router:
   locator:
     type: in_process
     control_plane:
-      url: http://127.0.0.1:9000
+      url: http://127.0.0.1:8000
     backup_route_store:
       type: filesystem
       base_dir: target/cache

--- a/example_config_locator.yaml
+++ b/example_config_locator.yaml
@@ -1,6 +1,6 @@
 locator:
   control_plane:
-    url: "http://127.0.0.1:9000"
+    url: "http://127.0.0.1:8000"
   backup_route_store:
     type: filesystem
     base_dir: target/cache

--- a/example_config_locator_gcs.yaml
+++ b/example_config_locator_gcs.yaml
@@ -3,7 +3,7 @@ locator:
     host: "0.0.0.0"
     port: 3000
   control_plane:
-    url: "http://127.0.0.1:9000"
+    url: "http://127.0.0.1:8000"
   backup_route_store:
     type: gcs
     bucket: synapse

--- a/example_config_proxy.yaml
+++ b/example_config_proxy.yaml
@@ -18,7 +18,7 @@ proxy:
     locality_to_default_cell:
       us: us1
     control_plane:
-      url: http://127.0.0.1:9000
+      url: http://127.0.0.1:8000
   upstreams:
   - name: us1-getsentry
     url: "http://127.0.0.1:8080"

--- a/ingest-router/src/testutils.rs
+++ b/ingest-router/src/testutils.rs
@@ -56,7 +56,7 @@ pub async fn create_test_locator(key_to_cell: HashMap<String, String>) -> Locato
 
     let service = locator::locator::Locator::new(
         locator::config::LocatorDataType::ProjectKey,
-        "http://invalid-control-plane:9000".to_string(),
+        "http://invalid-control-plane:8000".to_string(),
         provider,
         None,
         None,

--- a/locator/src/locator.rs
+++ b/locator/src/locator.rs
@@ -466,7 +466,7 @@ mod tests {
 
         let locator = Locator::new(
             LocatorDataType::Organization,
-            "http://invalid-control-plane:9000".to_string(),
+            "http://invalid-control-plane:8000".to_string(),
             provider,
             None,
             Some(HashMap::from([("de".into(), "de".into())])),

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -237,11 +237,11 @@ mod tests {
             upstreams: vec![
                 config::UpstreamConfig {
                     name: "upstream".to_string(),
-                    url: "http://127.0.0.1:9000".to_string(),
+                    url: "http://127.0.0.1:8100".to_string(),
                 },
                 config::UpstreamConfig {
                     name: "invalid_upstream".to_string(),
-                    url: "http://256.256.256.256:9000".to_string(),
+                    url: "http://256.256.256.256:8100".to_string(),
                 },
             ],
             routes: vec![
@@ -298,7 +298,7 @@ mod tests {
         let response = service.call(request).await.expect("Request failed");
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.headers().get("x-custom").unwrap(), "test");
-        assert_eq!(response.headers().get("host").unwrap(), "127.0.0.1:9000");
+        assert_eq!(response.headers().get("host").unwrap(), "127.0.0.1:8100");
         tracing::debug!("response headers: {:?}", response.headers());
         let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
         assert_eq!(body_bytes.as_ref(), content);

--- a/scripts/echo_server.py
+++ b/scripts/echo_server.py
@@ -40,6 +40,6 @@ class EchoHandler(BaseHTTPRequestHandler):
 
 
 if __name__ == "__main__":
-    server = HTTPServer(("127.0.0.1", 9000), EchoHandler)
-    print("Echo server listening on http://127.0.0.1:9000")
+    server = HTTPServer(("127.0.0.1", 8100), EchoHandler)
+    print("Echo server listening on http://127.0.0.1:8100")
     server.serve_forever()

--- a/scripts/mock_control_api.py
+++ b/scripts/mock_control_api.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     host = args.host or "127.0.0.1"
-    port = args.port or 9000
+    port = args.port or 8000
 
     server = HTTPServer((host, port), MockControlApi)
     print(f"Mock control plane listening on http://{host}:{port}")

--- a/synapse/src/config.rs
+++ b/synapse/src/config.rs
@@ -96,7 +96,7 @@ mod tests {
     fn proxy_config() {
         let proxy_yaml = r#"
             proxy:
-                upstreams: [{name: local, url: http://127.0.0.1:9000}]
+                upstreams: [{name: local, url: http://127.0.0.1:8100}]
                 routes: [{match: {path: test}, action: {to: local}}]
                 listener:
                     host: 0.0.0.0


### PR DESCRIPTION
Previously the default port for the mock control plane and proxy echo server was 9000, which collides with clickhouse client in a sentry dev environment. These are now moved to 8000 to match the real Sentry server -- allowing these to be easily substituted without changing ports.

The proxy echo server + test fixtures move from 9000 to 8100 to get off the ClickHouse port and avoid conflicts with the mock control plane.