### PR TITLE
devservices: Drop host matching rules in proxy and ingest-router

### DIFF
--- a/devservices/ingest-router.yaml
+++ b/devservices/ingest-router.yaml
@@ -28,35 +28,30 @@ ingest_router:
 
   routes:
     - match:
-        host: localhost
         path: /api/0/relays/projectconfigs/
         method: POST
       action:
         handler: relay_project_configs
       locality: "--monolith--"
     - match:
-        host: localhost
         path: /api/0/relays/live/
         method: GET
       action:
         handler: health
       locality: "--monolith--"
     - match:
-        host: localhost
         path: /api/0/relays/register/challenge/
         method: POST
       action:
         handler: register_challenge
       locality: "--monolith--"
     - match:
-        host: localhost
         path: /api/0/relays/register/response/
         method: POST
       action:
         handler: register_response
       locality: "--monolith--"
     - match:
-        host: localhost
         path: /api/0/relays/publickeys/
         method: POST
       action:

--- a/devservices/proxy.yaml
+++ b/devservices/proxy.yaml
@@ -23,7 +23,6 @@ proxy:
       url: http://host.docker.internal:8000
   routes:
     - match:
-        host: localhost
         path: /organizations/{organization}/*
       action:
         resolver: cell_from_organization


### PR DESCRIPTION
Removes the `host: localhost` match from the dev proxy and ingest-router routes so they accept the standard `dev.getsentry.net` URL devs already use, plus any other local hostnames we may want to use locally in multi-cell mode (`cell.dev.getsentry.net`, etc.).

Host matching adds no benefit or security in dev — port binding already scopes traffic to requests explicitly routed to synapse.