### PR TITLE
dev: Fix cache directory permissions for nonroot user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY shared ./shared
 
 RUN cargo build --release
 
-RUN mkdir /stage && cp --parents /usr/lib/$(gcc -print-multiarch)/libzstd.so.1 /stage
+RUN mkdir /stage /synapse-cache && cp --parents /usr/lib/$(gcc -print-multiarch)/libzstd.so.1 /stage
 
 # Runtime stage
 FROM gcr.io/distroless/cc-debian13:nonroot
@@ -26,6 +26,7 @@ WORKDIR /app
 
 COPY --from=builder /app/target/release/synapse synapse
 COPY --from=builder /stage/ /
+COPY --from=builder --chown=nonroot:nonroot /synapse-cache /tmp/synapse-cache
 
 ENTRYPOINT ["/app/synapse"]
 CMD []

--- a/devservices/ingest-router.yaml
+++ b/devservices/ingest-router.yaml
@@ -12,7 +12,6 @@ ingest_router:
       url: http://host.docker.internal:8000
     backup_route_store:
       type: filesystem
-      base_dir: /tmp/synapse-cache
       filename: backup.bin
       compression: zstd1
     localities:

--- a/devservices/proxy.yaml
+++ b/devservices/proxy.yaml
@@ -11,7 +11,6 @@ proxy:
       url: http://host.docker.internal:8000
     backup_route_store:
       type: filesystem
-      base_dir: /tmp/synapse-cache
       filename: backup.bin
       compression: zstd1
     localities:

--- a/locator/src/config.rs
+++ b/locator/src/config.rs
@@ -12,11 +12,16 @@ pub enum Compression {
     Zstd3,
 }
 
+fn default_base_dir() -> String {
+    "/tmp/synapse-cache".into()
+}
+
 #[derive(Clone, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type")]
 pub enum BackupRouteStoreType {
     Filesystem {
+        #[serde(default = "default_base_dir")]
         base_dir: String,
         filename: String,
         compression: Compression,


### PR DESCRIPTION
The distroless runtime image runs as `nonroot`, but `/tmp/synapse-cache` doesn't exist in the image — so when devservices mounts a named volume there, Docker creates the mountpoint as root and the locator's filesystem backup store fails to write.

Pre-create the directory in the builder stage and COPY it into the runtime image with `--chown=nonroot:nonroot`, so named volumes inherit nonroot ownership.

Since the path is now baked into the image, make `base_dir` optional in the locator config (defaulting to `/tmp/synapse-cache`) and drop the explicit setting from the devservices YAMLs.