### PR TITLE
proxy: Fix paths on proxy configuration

### DIFF
--- a/devservices/proxy.yaml
+++ b/devservices/proxy.yaml
@@ -24,7 +24,7 @@ proxy:
   routes:
     - match:
         host: localhost
-        path: /organizations/{organization}/*
+        path: /api/0/organizations/{organization}/*
       action:
         resolver: cell_from_organization
         cell_to_upstream:

--- a/example_config_proxy.yaml
+++ b/example_config_proxy.yaml
@@ -37,7 +37,7 @@ proxy:
   routes:
     - match:
         host: us.sentry.io
-        path: /organizations/{organization}/*
+        path: /api/0/organizations/{organization}/*
       action:
         resolver: cell_from_organization
         cell_to_upstream:
@@ -46,7 +46,7 @@ proxy:
         default: us1-getsentry
     - match:
         host: us.sentry.io
-        path: /cell/{cell_id}/*
+        path: /api/0/cell/{cell_id}/*
       action:
         resolver: cell_from_id
         cell_to_upstream:

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -40,7 +40,7 @@ Routes are matched top down in the order they are defined. For each incoming req
     ```yaml
     - match:
         host: us.sentry.io                                 # matches us.sentry.io only
-        path: /organizations/{organization_id_or_slug}/*   # with {organization_id_or_slug} dynamic segment and trailing wildcard
+        path: /api/0/organizations/{organization_id_or_slug}/*   # with {organization_id_or_slug} dynamic segment and trailing wildcard
     ```
 
 ### Route actions


### PR DESCRIPTION
sentry api paths are always prefixed with /api/0/..

this was missing in an earlier version of the configuration so it didn't work against the real sentry api