### PR TITLE
ingest-router: Pass project configs through unaltered

### DIFF
--- a/ingest-router/src/api/project_config.rs
+++ b/ingest-router/src/api/project_config.rs
@@ -65,7 +65,6 @@
 //!
 //! - **`configs`**: Map of public keys to their project configurations
 //!   - Configs are passed through unchanged from upstream Sentry instances
-//!   - The ingest router adds the `upstreamRelayUrl` field to each config based on the cell it came from
 //! - **`pending`**: Array of public keys for which configs are being computed asynchronously
 //!   - Relay should retry the request later to fetch these configs
 //!   - Also used when upstreams fail/timeout (graceful degradation)
@@ -96,8 +95,7 @@
 //!
 //! ### Configs (HashMap merge)
 //! - Merge all `configs` HashMaps from all upstreams
-//! - Add `upstreamRelayUrl` to each config based on which cell it came from
-//! - Other config fields are passed through unchanged from upstream
+//! - Configs are passed through unchanged from upstream
 //!
 //! ### Pending (Array concatenation)
 //! - Concatenate all `pending` arrays from all upstream responses
@@ -297,8 +295,6 @@ use serde_json::Value as JsonValue;
 use shared::http::make_error_response;
 use std::collections::HashMap;
 
-const UPSTREAM_RELAY_FIELD: &str = "upstreamRelayUrl";
-
 /// Request format for the relay project configs endpoint.
 ///
 /// # Example
@@ -380,8 +376,6 @@ struct ProjectConfigsMetadata {
     cell_to_keys: HashMap<CellId, Vec<String>>,
     // keys that couldn't be assigned to any cell
     unassigned_keys: Vec<String>,
-    // mapping from cell_id to relay_url for adding upstreamRelayUrl to configs
-    cell_to_relay_url: HashMap<CellId, String>,
 }
 
 /// Handler for the Relay Project Configs endpoint
@@ -445,19 +439,6 @@ impl Handler for ProjectConfigsHandler {
             }
         }
 
-        // Build cell_to_relay_url mapping for adding upstreamRelayUrl to configs during merge
-        let mut cell_to_relay_url: HashMap<CellId, String> = HashMap::new();
-        for cell_id in cell_to_keys.keys() {
-            if let Some(upstream) = cells.get_upstream(cell_id) {
-                cell_to_relay_url.insert(cell_id.clone(), upstream.relay_url.to_string());
-            } else {
-                tracing::warn!(
-                    cell_id = %cell_id,
-                    "Cell has keys but no upstream configured; upstreamRelayUrl will not be added to configs"
-                );
-            }
-        }
-
         let cell_requests = cell_to_keys
             .iter()
             .map(|(cell_id, keys)| {
@@ -475,7 +456,6 @@ impl Handler for ProjectConfigsHandler {
         let metadata = Box::new(ProjectConfigsMetadata {
             cell_to_keys,
             unassigned_keys: pending,
-            cell_to_relay_url,
         });
         Ok((cell_requests, metadata))
     }
@@ -529,24 +509,7 @@ impl Handler for ProjectConfigsHandler {
             }
 
             if let Ok(parsed) = deserialize_body::<ProjectConfigsResponse>(body) {
-                let relay_url = meta.cell_to_relay_url.get(&cell_id);
-
-                // Add upstreamRelayUrl to each config from this cell
-                let mut configs_with_relay_url = HashMap::new();
-                for (key, mut config) in parsed.project_configs {
-                    // Add upstreamRelayUrl to the config if we have it
-                    if let (Some(relay_url_str), Some(config_obj)) =
-                        (relay_url, config.as_object_mut())
-                    {
-                        config_obj.insert(
-                            UPSTREAM_RELAY_FIELD.to_string(),
-                            serde_json::Value::String(relay_url_str.clone()),
-                        );
-                    }
-                    configs_with_relay_url.insert(key, config);
-                }
-
-                merged.project_configs.extend(configs_with_relay_url);
+                merged.project_configs.extend(parsed.project_configs);
                 merged.extra_fields.extend(parsed.extra_fields);
                 merged.pending_keys.extend(parsed.pending_keys);
             } else {
@@ -770,10 +733,6 @@ mod tests {
                 ("us2".to_string(), vec!["key2".to_string()]),
             ]),
             unassigned_keys: Vec::new(),
-            cell_to_relay_url: HashMap::from([
-                ("us1".to_string(), "http://relay-us1:8090".to_string()),
-                ("us2".to_string(), "http://relay-us2:8090".to_string()),
-            ]),
         });
         let merged = handler.merge_responses(results, metadata).await;
 
@@ -781,23 +740,6 @@ mod tests {
 
         assert!(parsed.project_configs.contains_key("key1"));
         assert!(parsed.project_configs.contains_key("key2"));
-
-        // Verify upstreamRelayUrl field was added to each config
-        let key1_config = parsed.project_configs.get("key1").unwrap();
-        assert!(key1_config.is_object());
-        let key1_obj = key1_config.as_object().unwrap();
-        assert_eq!(
-            key1_obj.get(UPSTREAM_RELAY_FIELD),
-            Some(&serde_json::json!("http://relay-us1:8090"))
-        );
-
-        let key2_config = parsed.project_configs.get("key2").unwrap();
-        assert!(key2_config.is_object());
-        let key2_obj = key2_config.as_object().unwrap();
-        assert_eq!(
-            key2_obj.get(UPSTREAM_RELAY_FIELD),
-            Some(&serde_json::json!("http://relay-us2:8090"))
-        );
     }
 
     #[tokio::test]
@@ -839,10 +781,6 @@ mod tests {
                 "key_from_failed_cell1".to_string(),
                 "key_from_failed_cell2".to_string(),
             ],
-            cell_to_relay_url: HashMap::from([
-                ("us1".to_string(), "http://relay-us1:8090".to_string()),
-                ("us2".to_string(), "http://relay-us2:8090".to_string()),
-            ]),
         };
 
         let metadata: SplitMetadata = Box::new(pending_from_split);
@@ -854,23 +792,6 @@ mod tests {
         // Should have configs from successful responses
         assert!(parsed.project_configs.contains_key("key1"));
         assert!(parsed.project_configs.contains_key("key2"));
-
-        // Verify upstreamRelayUrl field was added to each config
-        let key1_config = parsed.project_configs.get("key1").unwrap();
-        assert!(key1_config.is_object());
-        let key1_obj = key1_config.as_object().unwrap();
-        assert_eq!(
-            key1_obj.get(UPSTREAM_RELAY_FIELD),
-            Some(&serde_json::json!("http://relay-us1:8090"))
-        );
-
-        let key2_config = parsed.project_configs.get("key2").unwrap();
-        assert!(key2_config.is_object());
-        let key2_obj = key2_config.as_object().unwrap();
-        assert_eq!(
-            key2_obj.get(UPSTREAM_RELAY_FIELD),
-            Some(&serde_json::json!("http://relay-us2:8090"))
-        );
 
         // Should have pending keys from split phase
         assert_eq!(parsed.pending_keys.len(), 3);


### PR DESCRIPTION
This functionality is now implemented in Relay.

Downstream Relays can inject and advertised upstream in project config.

Synapse no longer needs to inject upstreamRelayUrl into each project config and can pass them through unchanged.