### PR TITLE
devservices: Update relay_url to point at `relay-cell`

### DIFF
--- a/devservices/ingest-router.yaml
+++ b/devservices/ingest-router.yaml
@@ -23,7 +23,11 @@ ingest_router:
     "--monolith--":
       - id: "--monolith--"
         sentry_url: http://host.docker.internal:8000
-        relay_url: http://relay:7899
+        # Cell's processing relay in sentry's `cell-routing` devservices mode
+        # (replaces the default `relay`). Register + projectconfigs route here;
+        # envelopes bypass synapse and hit relay-cell directly via the
+        # advertised upstream.
+        relay_url: http://relay-cell:7900
 
   routes:
     - match:


### PR DESCRIPTION
This change supports `cell-routing` mode in sentry's devservices, which uses two relays in order to exercise the advertised upstream path, with Synapse in between.

The upstream of Synapse is the `relay-cell` service.