### PR TITLE
feat: add org avatar rule

### DIFF
--- a/devservices/proxy.yaml
+++ b/devservices/proxy.yaml
@@ -28,6 +28,13 @@ proxy:
         cell_to_upstream:
           "--monolith--": sentry-dev-monolith
         default: sentry-dev-monolith
+    - match:
+        path: /organization-avatar/{organization}/{avatar_id}
+      action:
+        resolver: cell_from_organization
+        cell_to_upstream:
+          "--monolith--": sentry-dev-monolith
+        default: sentry-dev-monolith
 
 metrics:
   statsd_host: "127.0.0.1"

--- a/example_config_proxy.yaml
+++ b/example_config_proxy.yaml
@@ -46,6 +46,15 @@ proxy:
         default: us1-getsentry
     - match:
         host: us.sentry.io
+        path: /organization-avatar/{organization}/{avatar_id}
+      action:
+        resolver: cell_from_organization
+        cell_to_upstream:
+          us1: us1-getsentry
+          us2: us2-getsentry
+        default: us1-getsentry
+    - match:
+        host: us.sentry.io
         path: /api/0/cell/{cell_id}/*
       action:
         resolver: cell_from_id

--- a/proxy/src/route_actions.rs
+++ b/proxy/src/route_actions.rs
@@ -374,7 +374,7 @@ mod tests {
 
     #[test]
     fn test_organization_avatar_slug_locator() {
-        // route on first segment after static prefix; org avatars are 
+        // route on first segment after static prefix; org avatars are
         // served from /organization-avatar/{slug}/{id}
         // (the avatar id is captured but ignored)
         let config = RouteConfig {

--- a/proxy/src/route_actions.rs
+++ b/proxy/src/route_actions.rs
@@ -371,4 +371,45 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn test_organization_avatar_slug_locator() {
+        // route on first segment after static prefix; org avatars are 
+        // served from /organization-avatar/{slug}/{id}
+        // (the avatar id is captured but ignored)
+        let config = RouteConfig {
+            r#match: crate::config::Match {
+                host: None,
+                path: Some("/organization-avatar/{organization}/{avatar_id}".to_string()),
+            },
+            action: crate::config::Action::Dynamic {
+                resolver: crate::config::Resolver::CellFromOrganization,
+                cell_to_upstream: HashMap::new(),
+                default: None,
+            },
+        };
+
+        let route = Route::try_from(config.clone()).unwrap();
+
+        assert_eq!(
+            route.matches(None, "/organization-avatar/my-org/abc123/"),
+            Some(RouteMatch {
+                params: HashMap::from([
+                    ("organization".to_string(), "my-org".to_string()),
+                    ("avatar_id".to_string(), "abc123".to_string()),
+                ]),
+                action: config.action.clone(),
+            }),
+            "captures the slug as `organization`, not the avatar id"
+        );
+
+        // the explicit two-segment org segment must not match
+        // deprecated, slug-less form (/organization-avatar/{id})
+        assert!(
+            route
+                .matches(None, "/organization-avatar/abc123/")
+                .is_none(),
+            "deprecated slug-less form must not match the slug locator"
+        );
+    }
 }


### PR DESCRIPTION
Problem:
Org avatars are served from `/organization-avatar/:slug/:id` instead of `/organizations/:slug/avatar`, because cookie-less asset URLs need a static path prefix and the latter doesn't have one (the slug comes first). Synapse routes by cell, so it needs to learn how to resolve this new path shape to the org's cell.

Fix:
Adds a slug-based locator route using the existing `cell_from_organization` resolver, which extracts the org slug from the captured `{organization}` segment and looks up its cell.

notes:
- path uses an explicit match rather than a trailing wildcard (`/{organization}/*`) because the same endpoint has a deprecated no-slug form, and this would match - incorrectly - with the wildcard

Refs INFRENG-324