### PR TITLE
fix clippy warnings

### DIFF
--- a/ingest-router/src/testutils.rs
+++ b/ingest-router/src/testutils.rs
@@ -10,9 +10,9 @@ use std::sync::Arc;
 pub async fn get_mock_provider() -> (tempfile::TempDir, FilesystemRouteProvider) {
     let route_data = RouteData::from(
         HashMap::from([
-            ("a".repeat(32).into(), "us1".into()),
-            ("b".repeat(32).into(), "us1".into()),
-            ("c".repeat(32).into(), "de".into()),
+            ("a".repeat(32), "us1".into()),
+            ("b".repeat(32), "us1".into()),
+            ("c".repeat(32), "de".into()),
         ]),
         Some("cursor1".into()),
         HashMap::from([("us1".into(), "us".into()), ("de".into(), "de".into())]),

--- a/shared/src/http.rs
+++ b/shared/src/http.rs
@@ -133,6 +133,27 @@ pub fn filter_hop_by_hop(headers: &mut HeaderMap, version: Version) -> &mut Head
     headers
 }
 
+/// Creates an error response with the status message as body.
+pub fn make_error_response(status_code: StatusCode) -> Response<Bytes> {
+    let message = status_code
+        .canonical_reason()
+        .unwrap_or("an error occurred");
+
+    let mut response = Response::new(Bytes::from(message));
+    *response.status_mut() = status_code;
+    response
+}
+
+/// Boxed version for services that need BoxBody (e.g., streaming proxies)
+pub fn make_boxed_error_response<E>(status_code: StatusCode) -> Response<BoxBody<Bytes, E>>
+where
+    E: 'static,
+{
+    make_error_response(status_code)
+        .map(Full::new)
+        .map(|body| body.map_err(|e| match e {}).boxed())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -162,25 +183,4 @@ mod tests {
         // Case-insensitive match with "cusTOM"
         assert!(filtered.get("custom").is_none());
     }
-}
-
-/// Creates an error response with the status message as body.
-pub fn make_error_response(status_code: StatusCode) -> Response<Bytes> {
-    let message = status_code
-        .canonical_reason()
-        .unwrap_or("an error occurred");
-
-    let mut response = Response::new(Bytes::from(message));
-    *response.status_mut() = status_code;
-    response
-}
-
-/// Boxed version for services that need BoxBody (e.g., streaming proxies)
-pub fn make_boxed_error_response<E>(status_code: StatusCode) -> Response<BoxBody<Bytes, E>>
-where
-    E: 'static,
-{
-    make_error_response(status_code)
-        .map(Full::new)
-        .map(|body| body.map_err(|e| match e {}).boxed())
 }

--- a/synapse/src/config.rs
+++ b/synapse/src/config.rs
@@ -161,12 +161,12 @@ mod tests {
         for entry in std::fs::read_dir(root_dir).unwrap() {
             let path = entry.unwrap().path();
 
-            if path.is_file() {
-                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                    if name.starts_with("example_config") && name.ends_with(".yaml") {
-                        let _ = Config::from_file(&path).expect("load config");
-                    }
-                }
+            if path.is_file()
+                && let Some(name) = path.file_name().and_then(|n| n.to_str())
+                && name.starts_with("example_config")
+                && name.ends_with(".yaml")
+            {
+                let _ = Config::from_file(&path).expect("load config");
             }
         }
     }


### PR DESCRIPTION
fixes clippy warnings around test ordering, nested ifs, useless type conversions