### PR TITLE
proxy: Add legacy sentry path patterns

### DIFF
--- a/devservices/proxy.yaml
+++ b/devservices/proxy.yaml
@@ -28,15 +28,11 @@ proxy:
         cell_to_upstream:
           "--monolith--": sentry-dev-monolith
         default: sentry-dev-monolith
-    # legacy project paths: /api/0/projects/{organization}/... is equivalent to
-    # /api/0/organizations/{organization}/projects/... in Sentry. The path is
-    # forwarded unchanged; we only extract {organization} to route.
+    # legacy project paths: /api/0/projects/{organization}/...
     - match:
         path: /api/0/projects/{organization}/*
       action: *monolith_org
-    # legacy team paths: /api/0/teams/{organization}/... is equivalent to
-    # /api/0/organizations/{organization}/teams/... in Sentry. The path is
-    # forwarded unchanged; we only extract {organization} to route.
+    # legacy team paths: /api/0/teams/{organization}/...
     - match:
         path: /api/0/teams/{organization}/*
       action: *monolith_org

--- a/devservices/proxy.yaml
+++ b/devservices/proxy.yaml
@@ -23,18 +23,26 @@ proxy:
   routes:
     - match:
         path: /api/0/organizations/{organization}/*
-      action:
+      action: &monolith_org
         resolver: cell_from_organization
         cell_to_upstream:
           "--monolith--": sentry-dev-monolith
         default: sentry-dev-monolith
+    # legacy project paths: /api/0/projects/{organization}/... is equivalent to
+    # /api/0/organizations/{organization}/projects/... in Sentry. The path is
+    # forwarded unchanged; we only extract {organization} to route.
+    - match:
+        path: /api/0/projects/{organization}/*
+      action: *monolith_org
+    # legacy team paths: /api/0/teams/{organization}/... is equivalent to
+    # /api/0/organizations/{organization}/teams/... in Sentry. The path is
+    # forwarded unchanged; we only extract {organization} to route.
+    - match:
+        path: /api/0/teams/{organization}/*
+      action: *monolith_org
     - match:
         path: /organization-avatar/{organization}/{avatar_id}
-      action:
-        resolver: cell_from_organization
-        cell_to_upstream:
-          "--monolith--": sentry-dev-monolith
-        default: sentry-dev-monolith
+      action: *monolith_org
 
 metrics:
   statsd_host: "127.0.0.1"

--- a/example_config_proxy.yaml
+++ b/example_config_proxy.yaml
@@ -44,16 +44,12 @@ proxy:
           us1: us1-getsentry
           us2: us2-getsentry
         default: us1-getsentry
-    # legacy project paths: /api/0/projects/{organization}/... is equivalent to
-    # /api/0/organizations/{organization}/projects/... in Sentry. The path is
-    # forwarded unchanged; we only extract {organization} to route.
+    # legacy project paths: /api/0/projects/{organization}/...
     - match:
         host: us.sentry.io
         path: /api/0/projects/{organization}/*
       action: *us_org
-    # legacy team paths: /api/0/teams/{organization}/... is equivalent to
-    # /api/0/organizations/{organization}/teams/... in Sentry. The path is
-    # forwarded unchanged; we only extract {organization} to route.
+    # legacy team paths: /api/0/teams/{organization}/...
     - match:
         host: us.sentry.io
         path: /api/0/teams/{organization}/*

--- a/example_config_proxy.yaml
+++ b/example_config_proxy.yaml
@@ -38,21 +38,30 @@ proxy:
     - match:
         host: us.sentry.io
         path: /api/0/organizations/{organization}/*
-      action:
+      action: &us_org
         resolver: cell_from_organization
         cell_to_upstream:
           us1: us1-getsentry
           us2: us2-getsentry
         default: us1-getsentry
+    # legacy project paths: /api/0/projects/{organization}/... is equivalent to
+    # /api/0/organizations/{organization}/projects/... in Sentry. The path is
+    # forwarded unchanged; we only extract {organization} to route.
+    - match:
+        host: us.sentry.io
+        path: /api/0/projects/{organization}/*
+      action: *us_org
+    # legacy team paths: /api/0/teams/{organization}/... is equivalent to
+    # /api/0/organizations/{organization}/teams/... in Sentry. The path is
+    # forwarded unchanged; we only extract {organization} to route.
+    - match:
+        host: us.sentry.io
+        path: /api/0/teams/{organization}/*
+      action: *us_org
     - match:
         host: us.sentry.io
         path: /organization-avatar/{organization}/{avatar_id}
-      action:
-        resolver: cell_from_organization
-        cell_to_upstream:
-          us1: us1-getsentry
-          us2: us2-getsentry
-        default: us1-getsentry
+      action: *us_org
     - match:
         host: us.sentry.io
         path: /api/0/cell/{cell_id}/*


### PR DESCRIPTION
Sentry supports two older legacy path patterns for organization scoped endpoints:
- `/api/0/projects/{organization}/{project}/...` - equivalent to `/api/0/organizations/{organization}/projects/{project}/...`
- `/api/0/teams/{organization}/{team}/..`. - equivalent to `/api/0/organizations/{organization}/teams/{team}/...`

Both are still used in the sentry UI and directly by customers. We need to support them in Synapse as deprecating these patterns will take a long time.